### PR TITLE
Unit tests for JSON configuration loading

### DIFF
--- a/logentries/configured_log.py
+++ b/logentries/configured_log.py
@@ -8,6 +8,7 @@ class ConfiguredLog(object):
 
     """Configured Log Class"""
 
+
     def __init__(self, name, token, destination, path, formatter, entry_identifier):
         self.name = name
         self.token = token
@@ -18,3 +19,16 @@ class ConfiguredLog(object):
         self.logset = None
         self.logset_id = None
         self.log_id = None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (self.name == other.name and
+                self.token == other.token and
+                self.destination == other.destination and
+                self.path == other.path and
+                self.formatter == other.formatter and
+                self.entry_identifier == other.entry_identifier and
+                self.logset == other.logset and
+                self.logset_id == other.logset_id and
+                self.log_id == other.logset_id)
+        return False

--- a/logentries/configured_log.py
+++ b/logentries/configured_log.py
@@ -8,7 +8,6 @@ class ConfiguredLog(object):
 
     """Configured Log Class"""
 
-
     def __init__(self, name, token, destination, path, formatter, entry_identifier):
         self.name = name
         self.token = token

--- a/logentries/metrics.py
+++ b/logentries/metrics.py
@@ -639,23 +639,7 @@ class MetricsConfig(object):
         # Basic metrics
         metricDict = conf.get(METRIC)
         for item in self.DEFAULTS:
-            try:
                 self.__dict__[item] = metricDict.get(PREFIX + item)
-            except ValueError:
-                pass
-        # Process metrics
-        try:
-            try:
-                token = metricDict.get(PREFIX + TOKEN)
-            except ValueError:
-                try:
-                    token = metricDict.get(TOKEN)
-                except ValueError:
-                    token = ''
-            pattern = metricDict.get(PREFIX + PROCESS)
-            self.processes.append([item, pattern, token])
-        except ValueError:
-            pass
 
     def load_ini(self, conf):
         """Loads metrics configuration."""

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -1,0 +1,175 @@
+import unittest
+from unittest import main
+import json
+import sys, os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../src")
+import sys
+import logging
+import mock
+from logentries.config import Config
+import logentries.metrics as metrics
+from logentries.configured_log import ConfiguredLog
+from collections import Counter
+
+class TestJsonConfig(unittest.TestCase):
+    json_file = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled": "true",
+          "metrics-interval": "60s",
+          "metrics-cpu": "system",
+          "metrics-vcpu": "core",
+          "metrics-mem": "system",
+          "metrics-swap": "system",
+          "metrics-net": "sum eth0",
+          "metrics-disk": "sum sda4 sda5",
+          "metrics-space": "/"
+        },
+        "logs": [
+          {
+            "name": "GreenLog",
+            "token": "a7f9625e-0d98-11e7-9b83-6c0b84a93740",
+            "path": "/var/log/GreenLog",
+            "enabled": "true"
+          }
+        ]
+      }
+    }'''
+
+    json_file_incorrect_token = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled": "true",
+          "metrics-interval": "60s",
+          "metrics-cpu": "system",
+          "metrics-vcpu": "core",
+          "metrics-mem": "system",
+          "metrics-swap": "system",
+          "metrics-net": "sum eth0",
+          "metrics-disk": "sum sda4 sda5",
+          "metrics-space": "/"
+        },
+        "logs": [
+          {
+            "name": "incorrect_token",
+            "token": "hello",
+            "path": "/var/log/incorrect_token",
+            "enabled": "true"
+          }
+        ]
+      }
+    }'''
+
+    json_file_no_path = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled": "true",
+          "metrics-interval": "60s",
+          "metrics-cpu": "system",
+          "metrics-vcpu": "core",
+          "metrics-mem": "system",
+          "metrics-swap": "system",
+          "metrics-net": "sum eth0",
+          "metrics-disk": "sum sda4 sda5",
+          "metrics-space": "/"
+        },
+        "logs": [
+          {
+            "name": "GreenLog",
+            "token": "09da4e87-882e-41f1-bf50-5f8888888888",
+            "enabled": "true"
+          }
+        ]
+      }
+    }'''
+
+
+    #    test the metrics.load_json() method correctly pulls the right parameters and associated values.
+    def test_metrics_load_json(self):
+        # Read in json config file
+        d_conf = json.loads(self.json_file)
+        d_configFile = d_conf['config']
+        self.metrics = metrics.MetricsConfig()
+        expected_dict = {'processes': [], 'net': 'sum eth0', 'space' : '/', 'disk': 'sum sda4 sda5', 'interval': '60s', 'swap': 'system',
+                         'vcpu': 'core', 'cpu': 'system', 'mem': 'system', 'token': None}
+
+        self.metrics.load_json(d_configFile)
+        result_dict = self.metrics.__dict__
+
+        self.assertDictEqual(result_dict, expected_dict, msg=None)
+
+    # test the _load_configured_logs_json() method correctly pulls the right parameters and associated values.
+    @mock.patch('logging.log')
+    def test_load_configured_logs_json(self, mock_logger):
+
+        # Read in json config file
+        d_conf = json.loads(self.json_file)
+        d_configFile = d_conf['config']
+
+        CONFIG = Config()
+
+        expected_log_list = []
+        expected_configured_log = ConfiguredLog('GreenLog', 'a7f9625e-0d98-11e7-9b83-6c0b84a93740', '', '/var/log/GreenLog', '', '')
+        expected_log_list.append(expected_configured_log)
+
+        CONFIG._load_configured_logs_json(d_configFile, mock_logger)
+        actual_log_result = CONFIG.configured_logs
+
+        self.assertEqual(Counter(expected_log_list), Counter(actual_log_result), msg=None)
+
+    # test the _load_configured_logs_json() when incorrect token entered
+    @mock.patch('logging.log')
+    def test_load_configured_logs_json_token(self, mock_logger):
+        CONFIG = Config()
+        name = "incorrect_token"
+        token = "hello"
+
+        # Read in json config file
+        d_conf = json.loads(self.json_file_incorrect_token)
+        d_configFile = d_conf['config']
+
+        CONFIG._load_configured_logs_json(d_configFile, mock_logger)
+
+        # result matches error message
+        mock_logger.warn.assert_called_with("Invalid log token `%s' in application `%s'.",
+                        token, name)
+
+    # test the _load_configured_logs_json() when path does not exist.
+    @mock.patch('logging.log')
+    def test_load_configured_logs_json_path(self, mock_logger):
+        CONFIG = Config()
+        name = 'GreenLog'
+        path = None
+
+        # Read in json config file
+        d_conf = json.loads(self.json_file_no_path)
+        d_configFile = d_conf['config']
+
+        CONFIG._load_configured_logs_json(d_configFile, mock_logger)
+
+        # result matches error message
+        mock_logger.debug.assert_called_with("Not following logs for application `%s' as `%s' "
+         "parameter is not specified", name, path)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -101,6 +101,36 @@ class TestJsonConfig(unittest.TestCase):
       }
     }'''
 
+    json_file_incorrect_names = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token-false": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled-false": "true",
+          "metrics-false": "60s",
+          "metrics-false": "system",
+          "metrics-false": "core",
+          "metrics-false": "system",
+          "metrics-false": "system",
+          "metrics-false": "sum eth0",
+          "metrics-false": "sum sda4 sda5",
+          "metrics-false": "/"
+        },
+        "logs": [
+          {
+            "name_false": "GreenLog",
+            "token_false": "09da4e87-882e-41f1-bf50-5f8888888888",
+            "path_false": "/var/log/incorrect_token",
+            "enabled_false": "true"
+          }
+        ]
+      }
+    }'''
+
 
     #    test the metrics.load_json() method correctly pulls the right parameters and associated values.
     def test_metrics_load_json(self):
@@ -110,6 +140,20 @@ class TestJsonConfig(unittest.TestCase):
         self.metrics = metrics.MetricsConfig()
         expected_dict = {'processes': [], 'net': 'sum eth0', 'space' : '/', 'disk': 'sum sda4 sda5', 'interval': '60s', 'swap': 'system',
                          'vcpu': 'core', 'cpu': 'system', 'mem': 'system', 'token': None}
+
+        self.metrics.load_json(d_configFile)
+        result_dict = self.metrics.__dict__
+
+        self.assertDictEqual(result_dict, expected_dict, msg=None)
+
+    #    test the metrics.load_json() method when incorrect parameter names are given
+    def test_metrics_load_json(self):
+        # Read in json config file
+        d_conf = json.loads(self.json_file_incorrect_names)
+        d_configFile = d_conf['config']
+        self.metrics = metrics.MetricsConfig()
+        expected_dict = {'processes': [], 'net': None, 'space' : None, 'disk': None, 'interval': None, 'swap': None,
+                         'vcpu': None, 'cpu': None, 'mem': None, 'token': None}
 
         self.metrics.load_json(d_configFile)
         result_dict = self.metrics.__dict__
@@ -131,7 +175,22 @@ class TestJsonConfig(unittest.TestCase):
         CONFIG._load_configured_logs_json(d_configFile, mock_logger)
         actual_log_result = CONFIG.configured_logs
 
-        self.assertEqual(Counter(expected_log_list), Counter(actual_log_result), msg=None)
+        self.assertCountEqual(expected_log_list, actual_log_result, msg=None)
+
+    # test the _load_configured_logs_json() when incorrect parameter names are given
+    @mock.patch('logging.log')
+    def test_load_configured_logs_json(self, mock_logger):
+        # Read in json config file
+        d_conf = json.loads(self.json_file_incorrect_names)
+        d_configFile = d_conf['config']
+        CONFIG = Config()
+
+        expected_log_list = []
+
+        CONFIG._load_configured_logs_json(d_configFile, mock_logger)
+        actual_log_result = CONFIG.configured_logs
+
+        self.assertCountEqual(expected_log_list, actual_log_result, msg=None)
 
     # test the _load_configured_logs_json() when incorrect token entered
     @mock.patch('logging.log')

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -1,9 +1,6 @@
 import unittest
 from unittest import main
 import json
-import sys, os
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../src")
-import sys
 import logging
 import mock
 from logentries.config import Config
@@ -64,7 +61,7 @@ class TestJsonConfig(unittest.TestCase):
         "logs": [
           {
             "name": "incorrect_token",
-            "token": "hello",
+            "token": "incorrect_token",
             "path": "/var/log/incorrect_token",
             "enabled": "true"
           }
@@ -132,7 +129,7 @@ class TestJsonConfig(unittest.TestCase):
     }'''
 
 
-    #    test the metrics.load_json() method correctly pulls the right parameters and associated values.
+    # test the metrics.load_json() method correctly pulls the right parameters and associated values.
     def test_metrics_load_json(self):
         # Read in json config file
         d_conf = json.loads(self.json_file)
@@ -146,7 +143,7 @@ class TestJsonConfig(unittest.TestCase):
 
         self.assertDictEqual(result_dict, expected_dict, msg=None)
 
-    #    test the metrics.load_json() method when incorrect parameter names are given
+    # test the metrics.load_json() method when incorrect parameter names are given.
     def test_metrics_load_json(self):
         # Read in json config file
         d_conf = json.loads(self.json_file_incorrect_names)
@@ -177,7 +174,7 @@ class TestJsonConfig(unittest.TestCase):
 
         self.assertCountEqual(expected_log_list, actual_log_result, msg=None)
 
-    # test the _load_configured_logs_json() when incorrect parameter names are given
+    # test the _load_configured_logs_json() when incorrect parameter names are given.
     @mock.patch('logging.log')
     def test_load_configured_logs_json(self, mock_logger):
         # Read in json config file
@@ -192,7 +189,7 @@ class TestJsonConfig(unittest.TestCase):
 
         self.assertCountEqual(expected_log_list, actual_log_result, msg=None)
 
-    # test the _load_configured_logs_json() when incorrect token entered
+    # test the _load_configured_logs_json() when incorrect token entered.
     @mock.patch('logging.log')
     def test_load_configured_logs_json_token(self, mock_logger):
         CONFIG = Config()

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -119,11 +119,9 @@ class TestJsonConfig(unittest.TestCase):
     # test the _load_configured_logs_json() method correctly pulls the right parameters and associated values.
     @mock.patch('logging.log')
     def test_load_configured_logs_json(self, mock_logger):
-
         # Read in json config file
         d_conf = json.loads(self.json_file)
         d_configFile = d_conf['config']
-
         CONFIG = Config()
 
         expected_log_list = []

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -197,7 +197,7 @@ class TestJsonConfig(unittest.TestCase):
     def test_load_configured_logs_json_token(self, mock_logger):
         CONFIG = Config()
         name = "incorrect_token"
-        token = "hello"
+        token = "incorrect_token"
 
         # Read in json config file
         d_conf = json.loads(self.json_file_incorrect_token)


### PR DESCRIPTION
Modified existing unit tests to assert the instances of the configuration files are correctly parsed. 
Removed processes and pattern from metrics.load_json()