### PR TITLE
Added json configuration support for windows event logs

### DIFF
--- a/logentries/config.py
+++ b/logentries/config.py
@@ -14,7 +14,8 @@ import logentries.metrics as metrics
 import logentries.utils as utils
 import logentries.log
 from logentries.configured_log import ConfiguredLog
-from logentries.constants import NOT_SET, EXIT_OK, MULTILOG_USAGE, DESTINATION_PARAM, TOKEN_PARAM
+from logentries.constants import NOT_SET, EXIT_OK, MULTILOG_USAGE, DESTINATION_PARAM, TOKEN_PARAM, \
+    WINDOWS_TOKEN_PARAM, WINDOWS_ENABLED
 
 
 DEFAULT_USER_KEY = NOT_SET
@@ -51,6 +52,7 @@ LE_DEFAULT_SSL_PORT = 20000
 LE_DEFAULT_NON_SSL_PORT = 10000
 CONFIG_PARAM = 'config'
 CONFIG_LOGS = 'logs'
+WINDOWS_LOGS = 'windows-eventlog'
 LOG_NAME = 'name'
 EMPTY = 0
 LOG = logentries.log.LOG
@@ -82,6 +84,7 @@ class Config(object):
         self.system_stats_token = NOT_SET
         self.pull_server_side_config = NOT_SET
         self.configured_logs = []
+        self.windows_eventlogs = {}
         self.metrics = metrics.MetricsConfig()
 
         # Special options
@@ -339,6 +342,7 @@ class Config(object):
 
             self.metrics.load_json(d_configFile)
             self._load_configured_logs_json(d_configFile, LOG.logger)
+            self._load_windows_configured_json(d_configFile, LOG.logger)
 
         except ValueError as e:
             LOG.logger.error("Error: %s JSON configuration not formatted correctly %s", config_file, e)
@@ -744,6 +748,28 @@ class Config(object):
             except OSError:
                 LOG.logger.warn('Could not adjust permissions for config file %s',
                              _config, exc_info=True)
+
+    def _load_windows_configured_json(self, conf, logger):
+        """
+            Loads configured windows parameters from the configuration file.
+            These parameters contain the token and settings for following windows event logs.
+        """
+        self.windows_eventlogs = {WINDOWS_ENABLED: 'false', WINDOWS_TOKEN_PARAM: None}
+
+        # check if windows event log is specified in the configuration file
+        if WINDOWS_LOGS in conf:
+            windows_conf = conf.get(WINDOWS_LOGS)
+            windows_enabled = windows_conf.get(WINDOWS_ENABLED)
+            wtoken = windows_conf.get(WINDOWS_TOKEN_PARAM)
+            if wtoken:
+                token = utils.uuid_parse(wtoken)
+                if not token:
+                    logger.warn("Invalid log token `%s' in application `%s'.",
+                                token, WINDOWS_LOGS)
+                else:
+                    self.windows_eventlogs[WINDOWS_ENABLED] = windows_enabled
+                    self.windows_eventlogs[WINDOWS_TOKEN_PARAM] = token
+
 
     def _load_configured_logs_json(self, conf, logger):
         """

--- a/logentries/config.py
+++ b/logentries/config.py
@@ -754,7 +754,7 @@ class Config(object):
             Loads configured windows parameters from the configuration file.
             These parameters contain the token and settings for following windows event logs.
         """
-        self.windows_eventlogs = {WINDOWS_ENABLED: 'false', WINDOWS_TOKEN_PARAM: None}
+        self.windows_eventlogs = {WINDOWS_ENABLED: False, WINDOWS_TOKEN_PARAM: None}
 
         # check if windows event log is specified in the configuration file
         if WINDOWS_LOGS in conf:

--- a/logentries/constants.py
+++ b/logentries/constants.py
@@ -205,3 +205,5 @@ EXIT_TERMINATED = 5  # Terminated by user (Ctrl+C)
 
 TOKEN_PARAM = 'token'
 DESTINATION_PARAM = 'destination'
+WINDOWS_TOKEN_PARAM = 'token'
+WINDOWS_ENABLED = 'enabled'

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -204,10 +204,10 @@ class TestJsonConfig(unittest.TestCase):
         d_configFile = d_conf['config']
         CONFIG = Config()
 
-        expected_dict = {'enabled' : 'true', 'token' : 'e684dc57-7240-4669-aa67-317e5493040a'}
+        expected_dict = {'enabled' : True, 'token' : 'e684dc57-7240-4669-aa67-317e5493040a'}
 
         CONFIG._load_windows_configured_json(d_configFile, mock_logger)
-        result_dict = CONFIG.windows_eventlog
+        result_dict = CONFIG.windows_eventlogs
 
         self.assertDictEqual(result_dict, expected_dict, msg=None)
 
@@ -232,14 +232,14 @@ class TestJsonConfig(unittest.TestCase):
     @mock.patch('logging.log')
     def test_load_windows_configured_json_empty(self, mock_logger):
         # Read in json config file
-        d_conf = json.loads(self.windows_json_file)
+        d_conf = json.loads(self.json_file)
         d_configFile = d_conf['config']
         CONFIG = Config()
 
-        expected_dict = {'enabled' : 'false', 'token' : None}
+        expected_dict = {'enabled' : False, 'token' : None}
 
         CONFIG._load_windows_configured_json(d_configFile, mock_logger)
-        result_dict = CONFIG.windows_eventlog
+        result_dict = CONFIG.windows_eventlogs
 
         self.assertDictEqual(result_dict, expected_dict, msg=None)
 

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -128,6 +128,121 @@ class TestJsonConfig(unittest.TestCase):
       }
     }'''
 
+    windows_json_file = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled": "true",
+          "metrics-interval": "60s",
+          "metrics-cpu": "system",
+          "metrics-vcpu": "core",
+          "metrics-mem": "system",
+          "metrics-swap": "system",
+          "metrics-net": "sum eth0",
+          "metrics-disk": "sum sda4 sda5",
+          "metrics-space": "/"
+        },
+        "logs": [
+          {
+            "name": "GreenLog",
+            "token": "a7f9625e-0d98-11e7-9b83-6c0b84a93740",
+            "path": "/var/log/GreenLog",
+            "enabled": "true"
+          }
+        ],
+        "windows-eventlog":{
+        "enabled": true,
+        "token": "e684dc57-7240-4669-aa67-317e5493040a"
+       }
+      }
+    }'''
+
+    windows_json_file_incorrect_token = '''{
+      "config": {
+        "hostname": "mgarewal",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "metrics": {
+          "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
+          "system-stat-enabled": "true",
+          "metrics-interval": "60s",
+          "metrics-cpu": "system",
+          "metrics-vcpu": "core",
+          "metrics-mem": "system",
+          "metrics-swap": "system",
+          "metrics-net": "sum eth0",
+          "metrics-disk": "sum sda4 sda5",
+          "metrics-space": "/"
+        },
+        "logs": [
+          {
+            "name": "GreenLog",
+            "token": "a7f9625e-0d98-11e7-9b83-6c0b84a93740",
+            "path": "/var/log/GreenLog",
+            "enabled": "true"
+          }
+        ],
+        "windows-eventlog":{
+        "enabled": true,
+        "token": "incorrect_token"
+       }
+      }
+    }'''
+
+    # test _load_windows_configured_logs_json() with the correct parameters given.
+    @mock.patch('logging.log')
+    def test_load_windows_configured_json(self, mock_logger):
+        # Read in json config file
+        d_conf = json.loads(self.windows_json_file)
+        d_configFile = d_conf['config']
+        CONFIG = Config()
+
+        expected_dict = {'enabled' : 'true', 'token' : 'e684dc57-7240-4669-aa67-317e5493040a'}
+
+        CONFIG._load_windows_configured_json(d_configFile, mock_logger)
+        result_dict = CONFIG.windows_eventlog
+
+        self.assertDictEqual(result_dict, expected_dict, msg=None)
+
+    # test load_windows_configured_logs_json() with an incorrect token given.
+    @mock.patch('logging.log')
+    def test_load_windows_configured_json_token(self, mock_logger):
+        name = "windows-eventlog"
+        token = None
+        CONFIG = Config()
+
+        # Read in json config file
+        d_conf = json.loads(self.windows_json_file_incorrect_token)
+        d_configFile = d_conf['config']
+
+        CONFIG._load_windows_configured_json(d_configFile, mock_logger)
+
+        # result matches error message
+        mock_logger.warn.assert_called_with("Invalid log token `%s' in application `%s'.",
+                        token, name)
+
+    # test load_windows_configured_logs_json() with no windows-eventlog section.
+    @mock.patch('logging.log')
+    def test_load_windows_configured_json_empty(self, mock_logger):
+        # Read in json config file
+        d_conf = json.loads(self.windows_json_file)
+        d_configFile = d_conf['config']
+        CONFIG = Config()
+
+        expected_dict = {'enabled' : 'false', 'token' : None}
+
+        CONFIG._load_windows_configured_json(d_configFile, mock_logger)
+        result_dict = CONFIG.windows_eventlog
+
+        self.assertDictEqual(result_dict, expected_dict, msg=None)
+
 
     # test the metrics.load_json() method correctly pulls the right parameters and associated values.
     def test_metrics_load_json(self):

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -11,7 +11,7 @@ from collections import Counter
 class TestJsonConfig(unittest.TestCase):
     json_file = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
@@ -41,7 +41,7 @@ class TestJsonConfig(unittest.TestCase):
 
     json_file_incorrect_token = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
@@ -71,7 +71,7 @@ class TestJsonConfig(unittest.TestCase):
 
     json_file_no_path = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
@@ -100,7 +100,7 @@ class TestJsonConfig(unittest.TestCase):
 
     json_file_incorrect_names = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
@@ -130,7 +130,7 @@ class TestJsonConfig(unittest.TestCase):
 
     windows_json_file = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
@@ -164,7 +164,7 @@ class TestJsonConfig(unittest.TestCase):
 
     windows_json_file_incorrect_token = '''{
       "config": {
-        "hostname": "mgarewal",
+        "hostname": "hgreenland",
         "endpoint": "data.logentries.com",
         "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
         "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",


### PR DESCRIPTION
Json configuration file can parse parameters specific for the windows event log following feature. 
If the window-eventlog section is not contained in the configuration file, the original log following process will continue as designed without windows event log following. 

config.py contains reference to self.windows_eventlogs, which is a dictionary used to hold the parameters "enabled" and "token" for windows event log following. The default value for these parameters is 'false', and None respectively. 