### PR TITLE
Fix metrics with json format and addresses unit-test issue

### DIFF
--- a/logentries/config.py
+++ b/logentries/config.py
@@ -790,8 +790,8 @@ class Config(object):
                 if PATH_PARAM in section:
                     path = section.get(PATH_PARAM)
                 if path is None:
-                    logger.debug("Not following logs for application `%s' as `%s' "
-                                  "parameter is not specified", name, path)
+                    logger.warn("Not following logs for application `%s' as `%s' "
+                                  "parameter is not specified", name, PATH_PARAM)
                     continue
 
                 destination = self._try_load_param_json(section, DESTINATION_PARAM)
@@ -826,7 +826,7 @@ class Config(object):
                 try:
                     path = conf.get(name, PATH_PARAM)
                 except ConfigParser.NoOptionError:
-                    LOG.logger.debug("Not following logs for application `%s' as `%s' "
+                    LOG.logger.warn("Not following logs for application `%s' as `%s' "
                                   "parameter is not specified", name, PATH_PARAM)
                     continue
 

--- a/logentries/config.py
+++ b/logentries/config.py
@@ -13,7 +13,7 @@ import logentries.utils as utils
 import logentries.log
 from logentries.configured_log import ConfiguredLog
 from logentries.constants import NOT_SET, EXIT_OK, MULTILOG_USAGE, DESTINATION_PARAM, TOKEN_PARAM, \
-    WINDOWS_TOKEN_PARAM, WINDOWS_ENABLED
+    WINDOWS_TOKEN_PARAM, ENABLED_PARAM
 
 DEFAULT_USER_KEY = NOT_SET
 DEFAULT_AGENT_KEY = NOT_SET
@@ -748,12 +748,12 @@ class Config(object):
             Loads configured windows parameters from the configuration file.
             These parameters contain the token and settings for following windows event logs.
         """
-        self.windows_eventlogs = {WINDOWS_ENABLED: False, WINDOWS_TOKEN_PARAM: None}
+        self.windows_eventlogs = {ENABLED_PARAM: False, WINDOWS_TOKEN_PARAM: None}
 
         # check if windows event log is specified in the configuration file
         if WINDOWS_LOGS in conf:
             windows_conf = conf.get(WINDOWS_LOGS)
-            windows_enabled = windows_conf.get(WINDOWS_ENABLED)
+            windows_enabled = windows_conf.get(ENABLED_PARAM)
             wtoken = windows_conf.get(WINDOWS_TOKEN_PARAM)
             if wtoken:
                 token = utils.uuid_parse(wtoken)
@@ -761,7 +761,7 @@ class Config(object):
                     logger.warn("Invalid log token `%s' in application `%s'.",
                                 token, WINDOWS_LOGS)
                 else:
-                    self.windows_eventlogs[WINDOWS_ENABLED] = windows_enabled
+                    self.windows_eventlogs[ENABLED_PARAM] = windows_enabled
                     self.windows_eventlogs[WINDOWS_TOKEN_PARAM] = token
 
 
@@ -797,9 +797,9 @@ class Config(object):
                 destination = self._try_load_param_json(section, DESTINATION_PARAM)
                 formatter = self._try_load_param_json(section, FORMATTER_PARAM)
                 entry_identifier = self._try_load_param_json(section, ENTRY_IDENTIFIER_PARAM)
+                enabled = self._try_load_param_json(section, ENABLED_PARAM)
 
-                configured_log = ConfiguredLog(name, token,
-                                               destination, path, formatter, entry_identifier)
+                configured_log = ConfiguredLog(enabled, name, token, destination, path, formatter, entry_identifier)
                 self.configured_logs.append(configured_log)
 
 
@@ -834,7 +834,7 @@ class Config(object):
                 formatter = self._try_load_param_ini(conf, name, FORMATTER_PARAM)
                 entry_identifier = self._try_load_param_ini(conf, name, ENTRY_IDENTIFIER_PARAM)
 
-                configured_log = ConfiguredLog(name, token,
+                configured_log = ConfiguredLog(True, name, token,
                                                destination, path, formatter, entry_identifier)
                 self.configured_logs.append(configured_log)
 

--- a/logentries/configured_log.py
+++ b/logentries/configured_log.py
@@ -8,7 +8,8 @@ class ConfiguredLog(object):
 
     """Configured Log Class"""
 
-    def __init__(self, name, token, destination, path, formatter, entry_identifier):
+    def __init__(self, enabled, name, token, destination, path, formatter, entry_identifier):
+        self.enabled = enabled
         self.name = name
         self.token = token
         self.destination = destination
@@ -21,7 +22,9 @@ class ConfiguredLog(object):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return (self.name == other.name and
+            return (
+                self.enabled == other.enabled and
+                self.name == other.name and
                 self.token == other.token and
                 self.destination == other.destination and
                 self.path == other.path and

--- a/logentries/constants.py
+++ b/logentries/constants.py
@@ -202,5 +202,5 @@ EXIT_TERMINATED = 5  # Terminated by user (Ctrl+C)
 
 TOKEN_PARAM = 'token'
 DESTINATION_PARAM = 'destination'
+ENABLED_PARAM = 'enabled'
 WINDOWS_TOKEN_PARAM = 'token'
-WINDOWS_ENABLED = 'enabled'

--- a/logentries/le.py
+++ b/logentries/le.py
@@ -779,7 +779,10 @@ def generate_headers():
 def _try_get_request(url, headers):
     """Generic rest GET request"""
     try:
-        return requests.request('GET', url, headers=headers)
+        if CONFIG.use_ca_provided is True:
+            return requests.request('GET', url, headers=headers, verify=utils.default_cert_file_name(CONFIG))
+        else:
+            return requests.request('GET', url, headers=headers)
     except (requests.RequestException, ValueError) as error:
         utils.die(error.message)
 

--- a/logentries/le.py
+++ b/logentries/le.py
@@ -921,7 +921,7 @@ def get_logset_by_name(logset_name):
     if logsets is not None:
         for item in logsets['logsets']:
             if item['name'] == logset_name:
-                return item
+                return {'logset': item}
     return None
 
 
@@ -932,10 +932,11 @@ def get_or_create_logset(logset_name):
 
     logset = get_logset_by_name(logset_name)
 
+    # If logset does not exist, create the logset
     if logset is None:
         logset = create_logset(logset_name)
 
-    return logset['id']
+    return logset['logset']['id']
 
 
 def get_or_create_log(logset_id, log_name):

--- a/logentries/le.py
+++ b/logentries/le.py
@@ -1513,7 +1513,7 @@ def monitor_from_local_config(args, shutdown_evt=threading.Event(), config_dir=N
     default_transport = DefaultTransport(CONFIG)
     formatter = formats.FormatSyslog(CONFIG.hostname, 'le', CONFIG.metrics.token)
 
-    if CONFIG.metrics.enabled:
+    if CONFIG.metrics.enabled is True and CONFIG.metrics is not None:
         LOG.logger.info('Initializing metrics')
         s_metrics = metrics.Metrics(CONFIG.metrics, default_transport, formatter, CONFIG.debug_metrics)
         s_metrics.start()

--- a/logentries/le.py
+++ b/logentries/le.py
@@ -1513,9 +1513,10 @@ def monitor_from_local_config(args, shutdown_evt=threading.Event(), config_dir=N
     default_transport = DefaultTransport(CONFIG)
     formatter = formats.FormatSyslog(CONFIG.hostname, 'le', CONFIG.metrics.token)
 
-    LOG.logger.info('Initializing metrics')
-    s_metrics = metrics.Metrics(CONFIG.metrics, default_transport, formatter, CONFIG.debug_metrics)
-    s_metrics.start()
+    if CONFIG.metrics.enabled:
+        LOG.logger.info('Initializing metrics')
+        s_metrics = metrics.Metrics(CONFIG.metrics, default_transport, formatter, CONFIG.debug_metrics)
+        s_metrics.start()
 
     followers = []
     transports = []

--- a/logentries/metrics.py
+++ b/logentries/metrics.py
@@ -637,11 +637,15 @@ class MetricsConfig(object):
     def load_json(self, conf):
         """Loads metrics configuration."""
         # Basic metrics
-        metricDict = conf.get(METRIC)
-        for item in self.DEFAULTS:
-                self.__dict__[item] = metricDict.get(METRIC_PREFIX + item)
-        self.token = metricDict.get(SYSTEM_STAT_PREFIX + TOKEN)
-        self.enabled = metricDict.get(SYSTEM_STAT_PREFIX + ENABLED)
+        metricsDict = conf.get(METRIC)
+        if metricsDict is None:
+            for item in self.DEFAULTS:
+                self.__dict__[item] = None
+        else:
+            for item in self.DEFAULTS:
+                    self.__dict__[item] = metricsDict.get(METRIC_PREFIX + item)
+            self.token = metricsDict.get(SYSTEM_STAT_PREFIX + TOKEN)
+            self.enabled = metricsDict.get(SYSTEM_STAT_PREFIX + ENABLED)
 
     def load_ini(self, conf):
         """Loads metrics configuration."""

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -245,13 +245,14 @@ class TestJsonConfig(unittest.TestCase):
 
 
     # test the metrics.load_json() method correctly pulls the right parameters and associated values.
-    def test_metrics_load_json(self):
+    def test_should_metrics_json(self):
         # Read in json config file
         d_conf = json.loads(self.json_file)
         d_configFile = d_conf['config']
         self.metrics = metrics.MetricsConfig()
-        expected_dict = {'processes': [], 'net': 'sum eth0', 'space' : '/', 'disk': 'sum sda4 sda5', 'interval': '60s', 'swap': 'system',
-                         'vcpu': 'core', 'cpu': 'system', 'mem': 'system', 'token': None}
+        expected_dict = {'processes': [], 'net': 'sum eth0', 'space' : '/', 'disk': 'sum sda4 sda5', 'interval': '60s',
+                         'swap': 'system', 'vcpu': 'core', 'cpu': 'system', 'mem': 'system',
+                         'token': '627d011e-0d97-11e7-9b83-6c0b84a93740', 'enabled': 'true'}
 
         self.metrics.load_json(d_configFile)
         result_dict = self.metrics.__dict__
@@ -259,13 +260,13 @@ class TestJsonConfig(unittest.TestCase):
         self.assertDictEqual(result_dict, expected_dict, msg=None)
 
     # test the metrics.load_json() method when incorrect parameter names are given.
-    def test_metrics_load_json(self):
+    def test_should_not_load_metrics_json(self):
         # Read in json config file
         d_conf = json.loads(self.json_file_incorrect_names)
         d_configFile = d_conf['config']
         self.metrics = metrics.MetricsConfig()
         expected_dict = {'processes': [], 'net': None, 'space' : None, 'disk': None, 'interval': None, 'swap': None,
-                         'vcpu': None, 'cpu': None, 'mem': None, 'token': None}
+                         'vcpu': None, 'cpu': None, 'mem': None, 'token': None, 'enabled': None}
 
         self.metrics.load_json(d_configFile)
         result_dict = self.metrics.__dict__
@@ -274,7 +275,7 @@ class TestJsonConfig(unittest.TestCase):
 
     # test the _load_configured_logs_json() method correctly pulls the right parameters and associated values.
     @mock.patch('logging.log')
-    def test_load_configured_logs_json(self, mock_logger):
+    def test_load_correct_configured_logs_json(self, mock_logger):
         # Read in json config file
         d_conf = json.loads(self.json_file)
         d_configFile = d_conf['config']
@@ -291,7 +292,7 @@ class TestJsonConfig(unittest.TestCase):
 
     # test the _load_configured_logs_json() when incorrect parameter names are given.
     @mock.patch('logging.log')
-    def test_load_configured_logs_json(self, mock_logger):
+    def test_load_incorrect_configured_logs_json(self, mock_logger):
         # Read in json config file
         d_conf = json.loads(self.json_file_incorrect_names)
         d_configFile = d_conf['config']
@@ -306,7 +307,7 @@ class TestJsonConfig(unittest.TestCase):
 
     # test the _load_configured_logs_json() when incorrect token entered.
     @mock.patch('logging.log')
-    def test_load_configured_logs_json_token(self, mock_logger):
+    def test_load_incorrect_token_configured_logs_json_token(self, mock_logger):
         CONFIG = Config()
         name = "incorrect_token"
         token = "incorrect_token"
@@ -323,7 +324,7 @@ class TestJsonConfig(unittest.TestCase):
 
     # test the _load_configured_logs_json() when path does not exist.
     @mock.patch('logging.log')
-    def test_load_configured_logs_json_path(self, mock_logger):
+    def test_load_configured_incorrect_path_logs_json_path(self, mock_logger):
         CONFIG = Config()
         name = 'GreenLog'
         path = None

--- a/test/test_json_config.py
+++ b/test/test_json_config.py
@@ -196,6 +196,24 @@ class TestJsonConfig(unittest.TestCase):
       }
     }'''
 
+    json_file_without_metrics = '''{
+      "config": {
+        "hostname": "hgreenland",
+        "endpoint": "data.logentries.com",
+        "user-key": "3d7946d4-0d97-11e7-9b83-6c0b84a93740",
+        "agent-key": "498fa2ba-0d97-11e7-9b83-6c0b84a93740",
+        "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
+        "logs": [
+          {
+            "name": "GreenLog",
+            "token": "a7f9625e-0d98-11e7-9b83-6c0b84a93740",
+            "path": "/var/log/GreenLog",
+            "enabled": "true"
+          }
+        ]
+      }
+    }'''
+
     # test _load_windows_configured_logs_json() with the correct parameters given.
     @mock.patch('logging.log')
     def test_load_windows_configured_json(self, mock_logger):
@@ -262,11 +280,11 @@ class TestJsonConfig(unittest.TestCase):
     # test the metrics.load_json() method when incorrect parameter names are given.
     def test_should_not_load_metrics_json(self):
         # Read in json config file
-        d_conf = json.loads(self.json_file_incorrect_names)
+        d_conf = json.loads(self.json_file_without_metrics)
         d_configFile = d_conf['config']
         self.metrics = metrics.MetricsConfig()
         expected_dict = {'processes': [], 'net': None, 'space' : None, 'disk': None, 'interval': None, 'swap': None,
-                         'vcpu': None, 'cpu': None, 'mem': None, 'token': None, 'enabled': None}
+                         'vcpu': None, 'cpu': None, 'mem': None, 'token': None, 'enabled': False}
 
         self.metrics.load_json(d_configFile)
         result_dict = self.metrics.__dict__


### PR DESCRIPTION
- Fixed metrics so that it processes enabled and token parameter
- Fixed the use of destination, it now calls the rest api, retrieves token or create a new log if needed
- Fixed the logs not being disabled when enabled: false
- Fixed unit-test

Testing
- [x] Using a logging.json without metrics - Checks that metrics is diabled
- [x] Using a logging.json with metrics - Checks that metrics is enabled and forward logs to logentries
- [x] Using a logging.json with LOG(token) configured - Checks that LOG is enabled and is forward logs to logentries
- [x] Using a logging.json with LOG(token) configured and disabled- Checks that LOG is disabled
- [x] Using a logging.json with LOG(destination) configured with preexisting destination - Checks LOG is enabled and is forwarding logs to logentries.
- [ ] Using a logging.json with LOG(destination) configured without preexisting destination - Checks LOG is enabled, log is created for logentries and is forwarding logs to logentries.