### PR TITLE
Change error handling of json configuration

### DIFF
--- a/logentries/le.py
+++ b/logentries/le.py
@@ -1497,9 +1497,8 @@ def monitor_from_local_config(args, shutdown_evt=threading.Event(), config_dir=N
         try:
             CONFIG.load()
             break
-        except FileNotFoundError:
-            LOG.logger.debug('Configuration file not found {}, retrying in {} seconds'.format(CONFIG.config_filename,
-                                                                                              retry))
+        except Exception as error:
+            LOG.logger.debug('Failed to load configuration file, retrying in {} seconds : {}'.format(retry, error))
             time.sleep(retry)
 
     LOG.logger.info('Initializing configured log from %s' % CONFIG.config_filename)


### PR DESCRIPTION
Change the error handling of json failures. 

- Instead of logging the json failure. Fail fast and early. Without a valid configuration. The agent has no way to function. 
- Improved logging message

Testing Done: 
- [x] Test without logging.json file. Verified log
- [x] Test with logging.json with invalid json format. Verified log.
- [x] Test with valid logging.json. Verified agent continue to function