### PR TITLE
Fixed get_or_create_log() method to extract token when a new destination is entered 

### DIFF
--- a/logentries/config.py
+++ b/logentries/config.py
@@ -41,9 +41,9 @@ HOSTNAME_PARAM = 'hostname'
 PATH_PARAM = 'path'
 INCLUDE_PARAM = 'include'
 PULL_SERVER_SIDE_CONFIG_PARAM = 'pull-server-side-config'
-PROXY_TYPE_PARAM = "proxy-type"
-PROXY_URL_PARAM = "proxy-url"
-PROXY_PORT_PARAM = "proxy-port"
+PROXY_TYPE_PARAM = 'proxy-type'
+PROXY_URL_PARAM = 'proxy-url'
+PROXY_PORT_PARAM = 'proxy-port'
 KEY_LEN = 36
 LE_DEFAULT_SSL_PORT = 20000
 LE_DEFAULT_NON_SSL_PORT = 10000
@@ -596,7 +596,7 @@ class Config(object):
             # Verify that only one wildcard is in pathname
             if pname.count('*') > 1:
                 if not cmd_line:
-                    LOG.logger.error("Error: More then one wildcard * detected in pathname")
+                    LOG.logger.error("Error: More than one wildcard * detected in pathname")
                     return False
                 else:
                     utils.die("\nError: Only one wildcard * allowed\n" + MULTILOG_USAGE, EXIT_OK)

--- a/logentries/le.py
+++ b/logentries/le.py
@@ -952,7 +952,7 @@ def get_or_create_log(logset_id, log_name):
     if not log_:
         # Try to create the log
         new_log = create_log(logset_id, log_name, '', do_follow=False, source='token')
-        new_log['log'].get('token', None)
+        log_ = new_log
 
 
     return extract_token(log_)

--- a/test/unittests/test_json_config.py
+++ b/test/unittests/test_json_config.py
@@ -402,7 +402,7 @@ class TestJsonConfig(unittest.TestCase):
     def test_load_configured_incorrect_path_logs_json_path(self, mock_logger):
         CONFIG = Config()
         name = 'GreenLog'
-        path = None
+        path = 'path'
 
         # Read in json config file
         d_conf = json.loads(self.json_file_no_path)
@@ -411,7 +411,7 @@ class TestJsonConfig(unittest.TestCase):
         CONFIG._load_configured_logs_json(d_configFile, mock_logger)
 
         # result matches error message
-        mock_logger.debug.assert_called_with("Not following logs for application `%s' as `%s' "
+        mock_logger.warn.assert_called_with("Not following logs for application `%s' as `%s' "
          "parameter is not specified", name, path)
 
 if __name__ == '__main__':

--- a/test/unittests/test_json_config.py
+++ b/test/unittests/test_json_config.py
@@ -18,7 +18,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled": "true",
+          "system-stat-enabled": true,
           "metrics-interval": "60s",
           "metrics-cpu": "system",
           "metrics-vcpu": "core",
@@ -48,7 +48,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled": "true",
+          "system-stat-enabled": true,
           "metrics-interval": "60s",
           "metrics-cpu": "system",
           "metrics-vcpu": "core",
@@ -78,7 +78,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled": "true",
+          "system-stat-enabled": true,
           "metrics-interval": "60s",
           "metrics-cpu": "system",
           "metrics-vcpu": "core",
@@ -107,7 +107,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token-false": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled-false": "true",
+          "system-stat-enabled-false": true,
           "metrics-false": "60s",
           "metrics-false": "system",
           "metrics-false": "core",
@@ -122,7 +122,7 @@ class TestJsonConfig(unittest.TestCase):
             "name_false": "GreenLog",
             "token_false": "09da4e87-882e-41f1-bf50-5f8888888888",
             "path_false": "/var/log/incorrect_token",
-            "enabled_false": "true"
+            "enabled_false": true
           }
         ]
       }
@@ -137,7 +137,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled": "true",
+          "system-stat-enabled": true,
           "metrics-interval": "60s",
           "metrics-cpu": "system",
           "metrics-vcpu": "core",
@@ -171,7 +171,7 @@ class TestJsonConfig(unittest.TestCase):
         "api-key": "555e7094-0d97-11e7-9b83-6c0b84a93740",
         "metrics": {
           "system-stat-token": "627d011e-0d97-11e7-9b83-6c0b84a93740",
-          "system-stat-enabled": "true",
+          "system-stat-enabled": true,
           "metrics-interval": "60s",
           "metrics-cpu": "system",
           "metrics-vcpu": "core",
@@ -288,14 +288,14 @@ class TestJsonConfig(unittest.TestCase):
 
 
     # test the metrics.load_json() method correctly pulls the right parameters and associated values.
-    def test_should_metrics_json(self):
+    def test_should_load_metrics_json(self):
         # Read in json config file
         d_conf = json.loads(self.json_file)
         d_configFile = d_conf['config']
         self.metrics = metrics.MetricsConfig()
         expected_dict = {'processes': [], 'net': 'sum eth0', 'space' : '/', 'disk': 'sum sda4 sda5', 'interval': '60s',
                          'swap': 'system', 'vcpu': 'core', 'cpu': 'system', 'mem': 'system',
-                         'token': '627d011e-0d97-11e7-9b83-6c0b84a93740', 'enabled': 'true'}
+                         'token': '627d011e-0d97-11e7-9b83-6c0b84a93740', 'enabled': True}
 
         self.metrics.load_json(d_configFile)
         result_dict = self.metrics.__dict__


### PR DESCRIPTION
When a new destination parameter is set, the token generated is correctly extracted using the get_or_create_log () method. 

- [x] Configured log following specifying a new (non-existing) destination parameter with enabled set to True.
- [x] Configured log following specifying a new (non-existing) destination parameter with enabled set to False.
- [x] Configured log following specifying an existing destination parameter with enabled set to True.
- [x] Configured log following specifying an existing destination parameter with enabled set to False. 